### PR TITLE
Allow pushgateway to specify encoder type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,10 @@ travis-ci = { repository = "pingcap/rust-prometheus" }
 features = ["nightly"]
 
 [features]
-default = ["protobuf"]
 gen = ["protobuf-codegen-pure"]
 nightly = ["libc"]
 process = ["libc", "procfs"]
-push = ["reqwest", "libc", "protobuf"]
+push = ["reqwest", "libc"]
 
 [dependencies]
 cfg-if = "^1.0"

--- a/examples/example_hyper.rs
+++ b/examples/example_hyper.rs
@@ -5,7 +5,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Body, Request, Response, Server,
 };
-use prometheus::{Counter, Encoder, Gauge, HistogramVec, TextEncoder};
+use prometheus::{Counter, Encoder, Gauge, HistogramVec, TextEncoder, EncoderFormatType};
 
 use lazy_static::lazy_static;
 use prometheus::{labels, opts, register_counter, register_gauge, register_histogram_vec};

--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -53,7 +53,7 @@ fn main() {
         PUSH_COUNTER.inc();
         let metric_families = prometheus::gather();
         let _timer = PUSH_REQ_HISTOGRAM.start_timer(); // drop as observe
-        prometheus::push_metrics(
+        prometheus::push_metrics_with_encoder(
             "example_push",
             labels! {"instance".to_owned() => "HAL-9000".to_owned(),},
             &address,
@@ -62,6 +62,7 @@ fn main() {
                 username: "user".to_owned(),
                 password: "pass".to_owned(),
             }),
+            prometheus::EncoderType::TextEncoder,
         )
         .unwrap();
     }

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -13,18 +13,31 @@ use std::io::Write;
 use crate::errors::{Error, Result};
 use crate::proto::MetricFamily;
 
+/// Encoder types
+#[derive(Debug)]
+pub enum EncoderType {
+    /// Plain text encoder type
+    TextEncoder,
+    /// Protobuf encoder type
+    #[cfg(feature = "protobuf")]
+    ProtobufEncoder,
+}
+
 /// An interface for encoding metric families into an underlying wire protocol.
-pub trait Encoder {
+pub trait Encoder<W: Write = Vec<u8>>: EncoderFormatType {
     /// `encode` converts a slice of MetricFamily proto messages into target
-    /// format and writes the resulting lines to `writer`. It returns the number
+    /// format and writes the resulting lines to `Write`. It returns the number
     /// of bytes written and any error encountered. This function does not
     /// perform checks on the content of the metric and label names,
     /// i.e. invalid metric or label names will result in invalid text format
     /// output.
-    fn encode<W: Write>(&self, _: &[MetricFamily], _: &mut W) -> Result<()>;
+    fn encode(&self, _: &[MetricFamily], _: &mut W ) -> Result<()>;
+}
 
-    /// `format_type` returns target format.
-    fn format_type(&self) -> &str;
+/// An interface to return encoder type
+pub trait EncoderFormatType {
+        /// `format_type` returns target format.
+        fn format_type(&self) -> &str;
 }
 
 fn check_metric_family(mf: &MetricFamily) -> Result<()> {

--- a/src/encoder/pb.rs
+++ b/src/encoder/pb.rs
@@ -1,13 +1,12 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+use protobuf::Message;
 
 use std::io::Write;
-
-use protobuf::Message;
 
 use crate::errors::Result;
 use crate::proto::MetricFamily;
 
-use super::{check_metric_family, Encoder};
+use super::{check_metric_family, Encoder, EncoderFormatType};
 
 /// The protocol buffer format of metric family.
 pub const PROTOBUF_FORMAT: &str = "application/vnd.google.protobuf; \
@@ -26,8 +25,11 @@ impl ProtobufEncoder {
     }
 }
 
-impl Encoder for ProtobufEncoder {
-    fn encode<W: Write>(&self, metric_families: &[MetricFamily], writer: &mut W) -> Result<()> {
+impl<W> Encoder<W> for ProtobufEncoder
+where
+    W: Write
+{
+    fn encode(&self, metric_families: &[MetricFamily], writer: &mut W) -> Result<()> {
         for mf in metric_families {
             // Fail-fast checks.
             check_metric_family(mf)?;
@@ -35,7 +37,9 @@ impl Encoder for ProtobufEncoder {
         }
         Ok(())
     }
+}
 
+impl EncoderFormatType for ProtobufEncoder {
     fn format_type(&self) -> &str {
         PROTOBUF_FORMAT
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,8 @@ pub use self::encoder::TextEncoder;
 #[cfg(feature = "protobuf")]
 pub use self::encoder::PROTOBUF_FORMAT;
 pub use self::encoder::TEXT_FORMAT;
+pub use self::encoder::EncoderType;
+pub use self::encoder::EncoderFormatType;
 pub use self::errors::{Error, Result};
 pub use self::gauge::{Gauge, GaugeVec, IntGauge, IntGaugeVec};
 pub use self::histogram::DEFAULT_BUCKETS;
@@ -222,6 +224,7 @@ pub use self::metrics::Opts;
 #[cfg(feature = "push")]
 pub use self::push::{
     hostname_grouping_key, push_add_collector, push_add_metrics, push_collector, push_metrics,
+    push_add_collector_with_encoder, push_add_metrics_with_encoder, push_collector_with_encoder, push_metrics_with_encoder,
     BasicAuthentication,
 };
 pub use self::registry::Registry;


### PR DESCRIPTION
Current default is protobuf, but there are requirements to send metrics over with plain text encoding.

Remove protobuf dependency from push feature and make it optional.

For existing push_* methods default encoder is now TextEncoder, if `protobuf` feature is not defined.

Add new public methods `push_add_collector_with_encoder, push_add_metrics_with_encoder, push_collector_with_encoder, push_metrics_with_encoder` that accept encoder type argument.